### PR TITLE
Add migrations files to gem to allow correct installation

### DIFF
--- a/decidim-url_aliases.gemspec
+++ b/decidim-url_aliases.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = "Decidim UrlAliases"
   s.description = "Decidim UrlAliases"
 
-  s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
   DECIDIM_VERSION = ">= 0.16.1"
 


### PR DESCRIPTION
Fixes "Don't know how to build task decidim_url_aliases:install:migrations" when running "bundle exec rake url_aliases:init" (issue #3)